### PR TITLE
Remove call for speakers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,3 @@ _From the people who brought you [React Sydney](https://www.meetup.com/React-Syd
 </div>
 
 ---
-
-## Speakers
-
-**Submit a talk at http://bit.ly/codeheartdesign-cfp**

--- a/docs/index.html
+++ b/docs/index.html
@@ -112,13 +112,8 @@
 
 			<section>
 				<h3>Speakers.</h3>
-				<p>
-					Got a great example to share?<br>
-					We&rsquo;re looking for speakers and would love to hear from you!<br>
-					<strong>Call for speakers closes October 3rd at 8pm</strong>
-				</p>
-
-				<a class="button button--secondary" href="http://bit.ly/codeheartdesign-cfp">Submit a talk</a>
+				<p><strong>The call for speakers has now closed.</strong></p>
+				<p>Thanks to everyone who submitted a talk! We&rsquo;ll update the schedule with a list of speakers soon.</p>
 			</section>
 
 			<section>


### PR DESCRIPTION
To be merged at 8pm on Wednesday 3rd October.

Removes:

- The button to submit a talk from the website
- The link to submit a talk from the `README.md` file